### PR TITLE
reduce-image-size: Use the slim version of python-3.11-bookworm and d…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
-FROM python:3.11-bookworm
+FROM python:3.11-slim-bookworm
 
 WORKDIR /app/simulator_worker
 
 COPY requirements.txt /app/requirements.txt
-RUN pip install -r /app/requirements.txt
+RUN pip install --no-cache-dir -r /app/requirements.txt
 
 
 COPY .  /app/simulator_worker/


### PR DESCRIPTION
…on't cache pip dependencies.